### PR TITLE
Don't log that we exclude models because we never do

### DIFF
--- a/cmd/eval-dev-quality/cmd/evaluate.go
+++ b/cmd/eval-dev-quality/cmd/evaluate.go
@@ -213,7 +213,7 @@ func (command *Evaluate) Execute(args []string) (err error) {
 					ps = append(ps, err)
 				}
 				if len(ps) > 0 {
-					log.Printf("Excluding model %q since it was not able to solve the %q repository for language %q: %+v", modelID, repositoryPath, languageID, ps)
+					log.Printf("Model %q was not able to solve the %q repository for language %q: %+v", modelID, repositoryPath, languageID, ps)
 					problemsPerModel[modelID] = append(problemsPerModel[modelID], ps...)
 				}
 			}


### PR DESCRIPTION
Was not adapted in f6965c583195c2c86d9969ed67038a0eacfe22c5