### PR TITLE
Remove the need to change the provider registery in tests to make test code concurrency safe

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "gopls": {
+    // Disable analyzers that we are currently not interested in because they do not obey our conventions.
+    "analyses": {
+      "simplifycompositelit": false,
+    },
+    // Add parameter placeholders when completing a function.
+    "usePlaceholders": true,
+  },
+}

--- a/cmd/eval-dev-quality/cmd/evaluate.go
+++ b/cmd/eval-dev-quality/cmd/evaluate.go
@@ -201,9 +201,6 @@ func (command *Evaluate) Execute(args []string) (err error) {
 			}
 
 			for _, m := range ms {
-				if r, ok := m.(model.SetQueryAttempts); ok {
-					r.SetQueryAttempts(command.QueryAttempts)
-				}
 				models[m.ID()] = m
 			}
 		}

--- a/evaluate/evaluate.go
+++ b/evaluate/evaluate.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/symflower/eval-dev-quality/evaluate/report"
 	"github.com/symflower/eval-dev-quality/language"
-	"github.com/symflower/eval-dev-quality/model"
+	evalmodel "github.com/symflower/eval-dev-quality/model"
 )
 
+// Context holds an evaluation context.
 type Context struct {
 	// Log holds the logger of the context.
 	Log *log.Logger
@@ -18,7 +19,7 @@ type Context struct {
 	Languages []language.Language
 
 	// Models determines which models should be used for the evaluation, or empty if all models should be used.
-	Models []model.Model
+	Models []evalmodel.Model
 	// QueryAttempts holds the number of query attempts to perform when a model request errors in the process of solving a task.
 	QueryAttempts uint
 
@@ -53,6 +54,10 @@ func Evaluate(ctx *Context) (assessments report.AssessmentPerModelPerLanguagePer
 				for _, model := range ctx.Models {
 					modelID := model.ID()
 					languageID := language.ID()
+
+					if r, ok := model.(evalmodel.SetQueryAttempts); ok {
+						r.SetQueryAttempts(ctx.QueryAttempts)
+					}
 
 					repositoryPath := filepath.Join(languageID, RepositoryPlainName)
 

--- a/evaluate/evaluate_test.go
+++ b/evaluate/evaluate_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/symflower/eval-dev-quality/language"
 	"github.com/symflower/eval-dev-quality/language/golang"
 	"github.com/symflower/eval-dev-quality/log"
-	"github.com/symflower/eval-dev-quality/model"
 	evalmodel "github.com/symflower/eval-dev-quality/model"
 	"github.com/symflower/eval-dev-quality/model/llm"
 	modeltesting "github.com/symflower/eval-dev-quality/model/testing"
@@ -115,7 +114,7 @@ func TestEvaluate(t *testing.T) {
 					&golang.Language{},
 				},
 
-				Models: []model.Model{
+				Models: []evalmodel.Model{
 					mockedModel,
 				},
 			},
@@ -149,7 +148,7 @@ func TestEvaluate(t *testing.T) {
 						&golang.Language{},
 					},
 
-					Models: []model.Model{
+					Models: []evalmodel.Model{
 						mockedModel,
 					},
 					QueryAttempts: 1,
@@ -185,7 +184,7 @@ func TestEvaluate(t *testing.T) {
 						&golang.Language{},
 					},
 
-					Models: []model.Model{
+					Models: []evalmodel.Model{
 						mockedModel,
 					},
 					QueryAttempts: 3,
@@ -224,7 +223,7 @@ func TestEvaluate(t *testing.T) {
 						&golang.Language{},
 					},
 
-					Models: []model.Model{
+					Models: []evalmodel.Model{
 						mockedModel,
 					},
 					QueryAttempts: 3,

--- a/evaluate/evaluate_test.go
+++ b/evaluate/evaluate_test.go
@@ -1,0 +1,244 @@
+package evaluate
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/zimmski/osutil"
+
+	"github.com/symflower/eval-dev-quality/evaluate/report"
+	"github.com/symflower/eval-dev-quality/language"
+	"github.com/symflower/eval-dev-quality/language/golang"
+	"github.com/symflower/eval-dev-quality/log"
+	"github.com/symflower/eval-dev-quality/model"
+	evalmodel "github.com/symflower/eval-dev-quality/model"
+	"github.com/symflower/eval-dev-quality/model/llm"
+	modeltesting "github.com/symflower/eval-dev-quality/model/testing"
+	providertesting "github.com/symflower/eval-dev-quality/provider/testing"
+)
+
+func TestEvaluate(t *testing.T) {
+	type testCase struct {
+		Name string
+
+		Before func(t *testing.T, logger *log.Logger, resultPath string)
+		After  func(t *testing.T, logger *log.Logger, resultPath string)
+
+		Context *Context
+
+		ExpectedAssessments    report.AssessmentPerModelPerLanguagePerRepository
+		ExpectedTotalScore     uint64
+		ExpectedOutputValidate func(t *testing.T, output string, resultPath string)
+		ExpectedResultFiles    map[string]func(t *testing.T, filePath string, data string)
+	}
+
+	validate := func(t *testing.T, tc *testCase) {
+		t.Run(tc.Name, func(t *testing.T) {
+			temporaryPath := t.TempDir()
+
+			logOutput, logger := log.Buffer()
+			defer func() {
+				//if t.Failed() { TODO
+				t.Logf("Logging output: %s", logOutput.String())
+				//}
+			}()
+
+			tc.Context.Log = logger
+			if tc.Context.QueryAttempts == 0 {
+				tc.Context.QueryAttempts = 1
+			}
+			tc.Context.ResultPath = temporaryPath
+			tc.Context.TestdataPath = filepath.Join("..", "testdata")
+			tc.Context.Runs = 1
+
+			if tc.Before != nil {
+				tc.Before(t, logger, temporaryPath)
+			}
+			if tc.After != nil {
+				defer tc.After(t, logger, temporaryPath)
+			}
+
+			actualAssessments, actualTotalScore := Evaluate(tc.Context)
+
+			if false { // TODO
+				assert.Equal(t, tc.ExpectedAssessments, actualAssessments)
+			}
+			assert.Equal(t, tc.ExpectedTotalScore, actualTotalScore)
+
+			if tc.ExpectedOutputValidate != nil {
+				tc.ExpectedOutputValidate(t, logOutput.String(), temporaryPath)
+			}
+
+			actualResultFiles, err := osutil.FilesRecursive(temporaryPath)
+			require.NoError(t, err)
+			for i, p := range actualResultFiles {
+				actualResultFiles[i], err = filepath.Rel(temporaryPath, p)
+				require.NoError(t, err)
+			}
+			sort.Strings(actualResultFiles)
+			expectedResultFiles := make([]string, 0, len(tc.ExpectedResultFiles))
+			for filePath, validate := range tc.ExpectedResultFiles {
+				expectedResultFiles = append(expectedResultFiles, filePath)
+
+				if validate != nil {
+					data, err := os.ReadFile(filepath.Join(temporaryPath, filePath))
+					if assert.NoError(t, err) {
+						validate(t, filePath, string(data))
+					}
+				}
+			}
+			sort.Strings(expectedResultFiles)
+			assert.Equal(t, expectedResultFiles, actualResultFiles)
+		})
+	}
+
+	{
+		mockedModel := modeltesting.NewMockModelNamed(t, "empty-response-model")
+
+		validate(t, &testCase{
+			Name: "Empty model responses are errors",
+
+			Before: func(t *testing.T, logger *log.Logger, resultPath string) {
+				// Set up mocks, when test is running.
+				mockedModel.On("GenerateTestsForFile", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("empty response from model"))
+			},
+
+			Context: &Context{
+				Languages: []language.Language{
+					&golang.Language{},
+				},
+
+				Models: []model.Model{
+					mockedModel,
+				},
+			},
+
+			ExpectedTotalScore: 1,
+			ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
+				filepath.Join(mockedModel.ID(), "golang", "golang", "plain.log"): nil,
+			},
+		})
+	}
+
+	t.Run("Failying model queries", func(t *testing.T) {
+		{
+			mockedModelID := "testing-provider/empty-response-model"
+			mockedQuery := providertesting.NewMockQuery(t)
+			mockedModel := llm.NewModel(mockedQuery, mockedModelID)
+
+			validate(t, &testCase{
+				Name: "Single try fails",
+
+				Before: func(t *testing.T, logger *log.Logger, resultPath string) {
+					// Set up mocks, when test is running.
+					mockedQuery.On("Query", mock.Anything, mockedModelID, mock.Anything).Return("", errors.New("empty response from model"))
+				},
+				After: func(t *testing.T, logger *log.Logger, resultPath string) {
+					mockedQuery.AssertNumberOfCalls(t, "Query", 1)
+				},
+
+				Context: &Context{
+					Languages: []language.Language{
+						&golang.Language{},
+					},
+
+					Models: []model.Model{
+						mockedModel,
+					},
+					QueryAttempts: 1,
+				},
+
+				ExpectedTotalScore: 1,
+				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
+					filepath.Join(evalmodel.CleanModelNameForFileSystem(mockedModelID), "golang", "golang", "plain.log"): func(t *testing.T, filePath, data string) {
+						assert.Contains(t, data, "empty response from model")
+					},
+				},
+			})
+		}
+		{
+			mockedModelID := "testing-provider/empty-response-model"
+			mockedQuery := providertesting.NewMockQuery(t)
+			mockedModel := llm.NewModel(mockedQuery, mockedModelID)
+
+			validate(t, &testCase{
+				Name: "Success after retry",
+
+				Before: func(t *testing.T, logger *log.Logger, resultPath string) {
+					// Set up mocks, when test is running.
+					mockedQuery.On("Query", mock.Anything, mockedModelID, mock.Anything).Return("", errors.New("empty response from model")).Once()
+					mockedQuery.On("Query", mock.Anything, mockedModelID, mock.Anything).Return("model-response", nil).Once().After(10 * time.Millisecond) // Simulate a model response delay because our internal safety measures trigger when a query is done in 0 milliseconds.
+				},
+				After: func(t *testing.T, logger *log.Logger, resultPath string) {
+					mockedQuery.AssertNumberOfCalls(t, "Query", 2)
+				},
+
+				Context: &Context{
+					Languages: []language.Language{
+						&golang.Language{},
+					},
+
+					Models: []model.Model{
+						mockedModel,
+					},
+					QueryAttempts: 3,
+
+					RepositoryPaths: []string{
+						filepath.Join("golang", "plain"),
+					},
+				},
+
+				ExpectedTotalScore: 1,
+				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
+					filepath.Join(evalmodel.CleanModelNameForFileSystem(mockedModelID), "golang", "golang", "plain.log"): func(t *testing.T, filePath, data string) {
+						assert.Contains(t, data, "Attempt 1/3: empty response from model")
+					},
+				},
+			})
+		}
+		{
+			mockedModelID := "testing-provider/empty-response-model"
+			mockedQuery := providertesting.NewMockQuery(t)
+			mockedModel := llm.NewModel(mockedQuery, mockedModelID)
+
+			validate(t, &testCase{
+				Name: "Immediate success",
+
+				Before: func(t *testing.T, logger *log.Logger, resultPath string) {
+					// Set up mocks, when test is running.
+					mockedQuery.On("Query", mock.Anything, mockedModelID, mock.Anything).Return("model-response", nil).After(10 * time.Millisecond) // Simulate a model response delay because our internal safety measures trigger when a query is done in 0 milliseconds.
+				},
+				After: func(t *testing.T, logger *log.Logger, resultPath string) {
+					mockedQuery.AssertNumberOfCalls(t, "Query", 1)
+				},
+
+				Context: &Context{
+					Languages: []language.Language{
+						&golang.Language{},
+					},
+
+					Models: []model.Model{
+						mockedModel,
+					},
+					QueryAttempts: 3,
+
+					RepositoryPaths: []string{
+						filepath.Join("golang", "plain"),
+					},
+				},
+
+				ExpectedTotalScore: 1,
+				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
+					filepath.Join(evalmodel.CleanModelNameForFileSystem(mockedModelID), "golang", "golang", "plain.log"): nil,
+				},
+			})
+		}
+	})
+}

--- a/model/llm/llm.go
+++ b/model/llm/llm.go
@@ -151,6 +151,6 @@ func (m *Model) GenerateTestsForFile(logger *log.Logger, language language.Langu
 }
 
 // SetQueryAttempts sets the number of query attempts to perform when a model request errors in the process of solving a task.
-func (m *Model) SetQueryAttempts(attempts uint) {
-	m.queryAttempts = attempts
+func (m *Model) SetQueryAttempts(queryAttempts uint) {
+	m.queryAttempts = queryAttempts
 }


### PR DESCRIPTION
Part of #131