### PR TITLE
Log the coverage objects, so this information is available and not lost

### DIFF
--- a/cmd/eval-dev-quality/cmd/evaluate_test.go
+++ b/cmd/eval-dev-quality/cmd/evaluate_test.go
@@ -371,8 +371,12 @@ func TestEvaluateExecute(t *testing.T) {
 				filepath.Join("result-directory", "README.md"): func(t *testing.T, filePath, data string) {
 					validateReportLinks(t, data, []string{"symflower_symbolic-execution"})
 				},
-				filepath.Join("result-directory", string(evaluatetask.IdentifierWriteTests), "symflower_symbolic-execution", "golang", "golang", "plain.log"): nil,
-				filepath.Join("result-directory", string(evaluatetask.IdentifierWriteTests), "symflower_symbolic-execution", "java", "java", "plain.log"):     nil,
+				filepath.Join("result-directory", string(evaluatetask.IdentifierWriteTests), "symflower_symbolic-execution", "golang", "golang", "plain.log"): func(t *testing.T, filePath, data string) {
+					assert.Contains(t, data, "coverage objects: [{")
+				},
+				filepath.Join("result-directory", string(evaluatetask.IdentifierWriteTests), "symflower_symbolic-execution", "java", "java", "plain.log"): func(t *testing.T, filePath, data string) {
+					assert.Contains(t, data, "coverage objects: [{")
+				},
 			},
 		})
 	})

--- a/language/coverage.go
+++ b/language/coverage.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 
 	pkgerrors "github.com/pkg/errors"
+	"github.com/symflower/eval-dev-quality/log"
 )
 
 // CoverageBlockUnfolded is an unfolded representation of a coverage data block.
@@ -23,11 +24,15 @@ type CoverageBlockUnfolded struct {
 var FileRangeMatch = regexp.MustCompile(`^(.+):(\d+):(\d+)-(.+):(\d+):(\d+)$`)
 
 // CoverageObjectCountOfFile parses the given coverage file and returns its coverage object count.
-func CoverageObjectCountOfFile(coverageFilePath string) (coverageObjectCount uint64, err error) {
+func CoverageObjectCountOfFile(logger *log.Logger, coverageFilePath string) (coverageObjectCount uint64, err error) {
 	coverageFile, err := os.ReadFile(coverageFilePath)
 	if err != nil {
 		return 0, pkgerrors.WithMessage(pkgerrors.WithStack(err), coverageFilePath)
 	}
+
+	// Log coverage objects.
+	logger.Printf("coverage objects: %s", string(coverageFile))
+
 	var coverageData []CoverageBlockUnfolded
 	if err := json.Unmarshal(coverageFile, &coverageData); err != nil {
 		return 0, pkgerrors.WithMessage(pkgerrors.WithStack(err), string(coverageFile))

--- a/language/golang/language.go
+++ b/language/golang/language.go
@@ -129,7 +129,7 @@ func (l *Language) Execute(logger *log.Logger, repositoryPath string) (coverage 
 		}
 	}
 
-	coverage, err = language.CoverageObjectCountOfFile(coverageFilePath)
+	coverage, err = language.CoverageObjectCountOfFile(logger, coverageFilePath)
 	if err != nil {
 		return 0, problems, pkgerrors.WithMessage(pkgerrors.WithStack(err), commandOutput)
 	}

--- a/language/java/language.go
+++ b/language/java/language.go
@@ -119,7 +119,7 @@ func (l *Language) Execute(logger *log.Logger, repositoryPath string) (coverage 
 		return 0, nil, pkgerrors.WithMessage(pkgerrors.WithStack(err), commandOutput)
 	}
 
-	coverage, err = language.CoverageObjectCountOfFile(coverageFilePath)
+	coverage, err = language.CoverageObjectCountOfFile(logger, coverageFilePath)
 	if err != nil {
 		return 0, nil, pkgerrors.WithMessage(pkgerrors.WithStack(err), commandOutput)
 	}


### PR DESCRIPTION
Part of #204