### PR TITLE
(minimal )asdf support for running the evaluations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ go.work
 
 # Ignore local configurations.
 .envrc
+
+# Ignore the evaluation directories
+/evaluation-*


### PR DESCRIPTION
I am using http://asdf-vm.com/ for my dev environment setup. 
It picks up the runtimes from the .tool-versions file. 
Compilation works fine but running the eval did not work because the tests are done in a temporary directory which do not have a .tool-versions file.
this attempts to fix this by just copying the .tool-versions file the temp folder. 
Works fine for me on MacOS, tests with some local ollama model. 



