### PR TITLE
Apply "symflower fix" to a "write-test" result of a model when it errors, so model responses can possibly be fixed

### DIFF
--- a/cmd/eval-dev-quality/cmd/evaluate_test.go
+++ b/cmd/eval-dev-quality/cmd/evaluate_test.go
@@ -199,87 +199,6 @@ func TestEvaluateExecute(t *testing.T) {
 			ExpectedOutputValidate: func(t *testing.T, output string, resultPath string) {
 				actualAssessments := validateMetrics(t, extractMetricsLogsMatch, output, []metrics.Assessments{
 					metrics.Assessments{
-						metrics.AssessmentKeyCoverage:         10,
-						metrics.AssessmentKeyFilesExecuted:    1,
-						metrics.AssessmentKeyResponseNoError:  1,
-						metrics.AssessmentKeyResponseNoExcess: 1,
-						metrics.AssessmentKeyResponseWithCode: 1,
-					},
-				}, []uint64{14})
-				// Assert non-deterministic behavior.
-				assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
-				assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
-				assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
-				assert.Equal(t, 1, strings.Count(output, "Evaluation score for"))
-			},
-			ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
-				filepath.Join("result-directory", "categories.svg"): func(t *testing.T, filePath, data string) {
-					validateSVGContent(t, data, []*metrics.AssessmentCategory{metrics.AssessmentCategoryCodeNoExcess}, 1)
-				},
-				filepath.Join("result-directory", "evaluation.csv"): func(t *testing.T, filePath, data string) {
-					actualAssessments := validateMetrics(t, extractMetricsCSVMatch, data, []metrics.Assessments{
-						metrics.Assessments{
-							metrics.AssessmentKeyCoverage:         10,
-							metrics.AssessmentKeyFilesExecuted:    1,
-							metrics.AssessmentKeyResponseNoError:  1,
-							metrics.AssessmentKeyResponseNoExcess: 1,
-							metrics.AssessmentKeyResponseWithCode: 1,
-						},
-					}, []uint64{14})
-					// Assert non-deterministic behavior.
-					assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
-					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
-					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
-				},
-				filepath.Join("result-directory", "evaluation.log"): nil,
-				filepath.Join("result-directory", "golang-summed.csv"): func(t *testing.T, filePath, data string) {
-					actualAssessments := validateMetrics(t, extractMetricsCSVMatch, data, []metrics.Assessments{
-						metrics.Assessments{
-							metrics.AssessmentKeyCoverage:         10,
-							metrics.AssessmentKeyFilesExecuted:    1,
-							metrics.AssessmentKeyResponseNoError:  1,
-							metrics.AssessmentKeyResponseNoExcess: 1,
-							metrics.AssessmentKeyResponseWithCode: 1,
-						},
-					}, []uint64{14})
-					// Assert non-deterministic behavior.
-					assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
-					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
-					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
-				},
-				filepath.Join("result-directory", "models-summed.csv"): func(t *testing.T, filePath, data string) {
-					actualAssessments := validateMetrics(t, extractMetricsCSVMatch, data, []metrics.Assessments{
-						metrics.Assessments{
-							metrics.AssessmentKeyCoverage:         10,
-							metrics.AssessmentKeyFilesExecuted:    1,
-							metrics.AssessmentKeyResponseNoError:  1,
-							metrics.AssessmentKeyResponseNoExcess: 1,
-							metrics.AssessmentKeyResponseWithCode: 1,
-						},
-					}, []uint64{14})
-					// Assert non-deterministic behavior.
-					assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
-					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
-					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
-				},
-				filepath.Join("result-directory", "README.md"): func(t *testing.T, filePath, data string) {
-					validateReportLinks(t, data, []string{"symflower_symbolic-execution"})
-				},
-				filepath.Join("result-directory", string(evaluatetask.IdentifierWriteTests), "symflower_symbolic-execution", "golang", "golang", "plain.log"): nil,
-			},
-		})
-		validate(t, &testCase{
-			Name: "Multiple",
-
-			Arguments: []string{
-				"--model", "symflower/symbolic-execution",
-				"--repository", filepath.Join("golang", "plain"),
-				"--repository", filepath.Join("java", "plain"),
-			},
-
-			ExpectedOutputValidate: func(t *testing.T, output string, resultPath string) {
-				actualAssessments := validateMetrics(t, extractMetricsLogsMatch, output, []metrics.Assessments{
-					metrics.Assessments{
 						metrics.AssessmentKeyCoverage:         20,
 						metrics.AssessmentKeyFilesExecuted:    2,
 						metrics.AssessmentKeyResponseNoError:  2,
@@ -289,8 +208,8 @@ func TestEvaluateExecute(t *testing.T) {
 				}, []uint64{28})
 				// Assert non-deterministic behavior.
 				assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
-				assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(393))
-				assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(393))
+				assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(508))
+				assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(508))
 				assert.Equal(t, 1, strings.Count(output, "Evaluation score for"))
 			},
 			ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
@@ -319,38 +238,24 @@ func TestEvaluateExecute(t *testing.T) {
 					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
 					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
 					assert.Greater(t, actualAssessments[1][metrics.AssessmentKeyProcessingTime], uint64(0))
-					assert.Equal(t, actualAssessments[1][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(139))
-					assert.Equal(t, actualAssessments[1][metrics.AssessmentKeyResponseCharacterCount], uint64(139))
+					assert.Equal(t, actualAssessments[1][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
+					assert.Equal(t, actualAssessments[1][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
 				},
+				filepath.Join("result-directory", "evaluation.log"): nil,
 				filepath.Join("result-directory", "golang-summed.csv"): func(t *testing.T, filePath, data string) {
 					actualAssessments := validateMetrics(t, extractMetricsCSVMatch, data, []metrics.Assessments{
 						metrics.Assessments{
-							metrics.AssessmentKeyCoverage:         10,
-							metrics.AssessmentKeyFilesExecuted:    1,
-							metrics.AssessmentKeyResponseNoError:  1,
-							metrics.AssessmentKeyResponseNoExcess: 1,
-							metrics.AssessmentKeyResponseWithCode: 1,
+							metrics.AssessmentKeyCoverage:         20,
+							metrics.AssessmentKeyFilesExecuted:    2,
+							metrics.AssessmentKeyResponseNoError:  2,
+							metrics.AssessmentKeyResponseNoExcess: 2,
+							metrics.AssessmentKeyResponseWithCode: 2,
 						},
-					}, []uint64{14})
+					}, []uint64{28})
 					// Assert non-deterministic behavior.
 					assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
-					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
-					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
-				},
-				filepath.Join("result-directory", "java-summed.csv"): func(t *testing.T, filePath, data string) {
-					actualAssessments := validateMetrics(t, extractMetricsCSVMatch, data, []metrics.Assessments{
-						metrics.Assessments{
-							metrics.AssessmentKeyCoverage:         10,
-							metrics.AssessmentKeyFilesExecuted:    1,
-							metrics.AssessmentKeyResponseNoError:  1,
-							metrics.AssessmentKeyResponseNoExcess: 1,
-							metrics.AssessmentKeyResponseWithCode: 1,
-						},
-					}, []uint64{14})
-					// Assert non-deterministic behavior.
-					assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
-					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(139))
-					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(139))
+					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(508))
+					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(508))
 				},
 				filepath.Join("result-directory", "models-summed.csv"): func(t *testing.T, filePath, data string) {
 					actualAssessments := validateMetrics(t, extractMetricsCSVMatch, data, []metrics.Assessments{
@@ -364,8 +269,133 @@ func TestEvaluateExecute(t *testing.T) {
 					}, []uint64{28})
 					// Assert non-deterministic behavior.
 					assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
-					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(393))
-					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(393))
+					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(508))
+					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(508))
+				},
+				filepath.Join("result-directory", "README.md"): func(t *testing.T, filePath, data string) {
+					validateReportLinks(t, data, []string{"symflower_symbolic-execution"})
+				},
+				filepath.Join("result-directory", string(evaluatetask.IdentifierWriteTests), "symflower_symbolic-execution", "golang", "golang", "plain.log"): nil,
+			},
+		})
+		validate(t, &testCase{
+			Name: "Multiple",
+
+			Arguments: []string{
+				"--model", "symflower/symbolic-execution",
+				"--repository", filepath.Join("golang", "plain"),
+				"--repository", filepath.Join("java", "plain"),
+			},
+
+			ExpectedOutputValidate: func(t *testing.T, output string, resultPath string) {
+				actualAssessments := validateMetrics(t, extractMetricsLogsMatch, output, []metrics.Assessments{
+					metrics.Assessments{
+						metrics.AssessmentKeyCoverage:         40,
+						metrics.AssessmentKeyFilesExecuted:    4,
+						metrics.AssessmentKeyResponseNoError:  4,
+						metrics.AssessmentKeyResponseNoExcess: 4,
+						metrics.AssessmentKeyResponseWithCode: 4,
+					},
+				}, []uint64{56})
+				// Assert non-deterministic behavior.
+				assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
+				assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(786))
+				assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(786))
+				assert.Equal(t, 1, strings.Count(output, "Evaluation score for"))
+			},
+			ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
+				filepath.Join("result-directory", "categories.svg"): func(t *testing.T, filePath, data string) {
+					validateSVGContent(t, data, []*metrics.AssessmentCategory{metrics.AssessmentCategoryCodeNoExcess}, 1)
+				},
+				filepath.Join("result-directory", "evaluation.csv"): func(t *testing.T, filePath, data string) {
+					actualAssessments := validateMetrics(t, extractMetricsCSVMatch, data, []metrics.Assessments{
+						metrics.Assessments{
+							metrics.AssessmentKeyCoverage:         10,
+							metrics.AssessmentKeyFilesExecuted:    1,
+							metrics.AssessmentKeyResponseNoError:  1,
+							metrics.AssessmentKeyResponseNoExcess: 1,
+							metrics.AssessmentKeyResponseWithCode: 1,
+						},
+						metrics.Assessments{
+							metrics.AssessmentKeyCoverage:         10,
+							metrics.AssessmentKeyFilesExecuted:    1,
+							metrics.AssessmentKeyResponseNoError:  1,
+							metrics.AssessmentKeyResponseNoExcess: 1,
+							metrics.AssessmentKeyResponseWithCode: 1,
+						},
+						metrics.Assessments{
+							metrics.AssessmentKeyCoverage:         10,
+							metrics.AssessmentKeyFilesExecuted:    1,
+							metrics.AssessmentKeyResponseNoError:  1,
+							metrics.AssessmentKeyResponseNoExcess: 1,
+							metrics.AssessmentKeyResponseWithCode: 1,
+						},
+						metrics.Assessments{
+							metrics.AssessmentKeyCoverage:         10,
+							metrics.AssessmentKeyFilesExecuted:    1,
+							metrics.AssessmentKeyResponseNoError:  1,
+							metrics.AssessmentKeyResponseNoExcess: 1,
+							metrics.AssessmentKeyResponseWithCode: 1,
+						},
+					}, []uint64{14, 14, 14, 14})
+					// Assert non-deterministic behavior.
+					assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
+					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
+					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
+					assert.Greater(t, actualAssessments[1][metrics.AssessmentKeyProcessingTime], uint64(0))
+					assert.Equal(t, actualAssessments[1][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
+					assert.Equal(t, actualAssessments[1][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
+					assert.Greater(t, actualAssessments[2][metrics.AssessmentKeyProcessingTime], uint64(0))
+					assert.Equal(t, actualAssessments[2][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(139))
+					assert.Equal(t, actualAssessments[2][metrics.AssessmentKeyResponseCharacterCount], uint64(139))
+					assert.Greater(t, actualAssessments[3][metrics.AssessmentKeyProcessingTime], uint64(0))
+					assert.Equal(t, actualAssessments[3][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(139))
+					assert.Equal(t, actualAssessments[3][metrics.AssessmentKeyResponseCharacterCount], uint64(139))
+				},
+				filepath.Join("result-directory", "golang-summed.csv"): func(t *testing.T, filePath, data string) {
+					actualAssessments := validateMetrics(t, extractMetricsCSVMatch, data, []metrics.Assessments{
+						metrics.Assessments{
+							metrics.AssessmentKeyCoverage:         20,
+							metrics.AssessmentKeyFilesExecuted:    2,
+							metrics.AssessmentKeyResponseNoError:  2,
+							metrics.AssessmentKeyResponseNoExcess: 2,
+							metrics.AssessmentKeyResponseWithCode: 2,
+						},
+					}, []uint64{28})
+					// Assert non-deterministic behavior.
+					assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
+					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(508))
+					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(508))
+				},
+				filepath.Join("result-directory", "java-summed.csv"): func(t *testing.T, filePath, data string) {
+					actualAssessments := validateMetrics(t, extractMetricsCSVMatch, data, []metrics.Assessments{
+						metrics.Assessments{
+							metrics.AssessmentKeyCoverage:         20,
+							metrics.AssessmentKeyFilesExecuted:    2,
+							metrics.AssessmentKeyResponseNoError:  2,
+							metrics.AssessmentKeyResponseNoExcess: 2,
+							metrics.AssessmentKeyResponseWithCode: 2,
+						},
+					}, []uint64{28})
+					// Assert non-deterministic behavior.
+					assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
+					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(278))
+					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(278))
+				},
+				filepath.Join("result-directory", "models-summed.csv"): func(t *testing.T, filePath, data string) {
+					actualAssessments := validateMetrics(t, extractMetricsCSVMatch, data, []metrics.Assessments{
+						metrics.Assessments{
+							metrics.AssessmentKeyCoverage:         40,
+							metrics.AssessmentKeyFilesExecuted:    4,
+							metrics.AssessmentKeyResponseNoError:  4,
+							metrics.AssessmentKeyResponseNoExcess: 4,
+							metrics.AssessmentKeyResponseWithCode: 4,
+						},
+					}, []uint64{56})
+					// Assert non-deterministic behavior.
+					assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
+					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(786))
+					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(786))
 				},
 				filepath.Join("result-directory", "evaluation.log"): nil,
 				filepath.Join("result-directory", "README.md"): func(t *testing.T, filePath, data string) {
@@ -395,17 +425,17 @@ func TestEvaluateExecute(t *testing.T) {
 				ExpectedOutputValidate: func(t *testing.T, output string, resultPath string) {
 					actualAssessments := validateMetrics(t, extractMetricsLogsMatch, output, []metrics.Assessments{
 						metrics.Assessments{
-							metrics.AssessmentKeyCoverage:         10,
-							metrics.AssessmentKeyFilesExecuted:    1,
-							metrics.AssessmentKeyResponseNoError:  1,
-							metrics.AssessmentKeyResponseNoExcess: 1,
-							metrics.AssessmentKeyResponseWithCode: 1,
+							metrics.AssessmentKeyCoverage:         20,
+							metrics.AssessmentKeyFilesExecuted:    2,
+							metrics.AssessmentKeyResponseNoError:  2,
+							metrics.AssessmentKeyResponseNoExcess: 2,
+							metrics.AssessmentKeyResponseWithCode: 2,
 						},
-					}, []uint64{14})
+					}, []uint64{28})
 					// Assert non-deterministic behavior.
 					assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
-					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
-					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
+					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(508))
+					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(508))
 					assert.Equal(t, 1, strings.Count(output, "Evaluation score for"))
 				},
 				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
@@ -421,42 +451,52 @@ func TestEvaluateExecute(t *testing.T) {
 								metrics.AssessmentKeyResponseNoExcess: 1,
 								metrics.AssessmentKeyResponseWithCode: 1,
 							},
-						}, []uint64{14})
+							metrics.Assessments{
+								metrics.AssessmentKeyCoverage:         10,
+								metrics.AssessmentKeyFilesExecuted:    1,
+								metrics.AssessmentKeyResponseNoError:  1,
+								metrics.AssessmentKeyResponseNoExcess: 1,
+								metrics.AssessmentKeyResponseWithCode: 1,
+							},
+						}, []uint64{14, 14})
 						// Assert non-deterministic behavior.
 						assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
 						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
 						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
+						assert.Greater(t, actualAssessments[1][metrics.AssessmentKeyProcessingTime], uint64(0))
+						assert.Equal(t, actualAssessments[1][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
+						assert.Equal(t, actualAssessments[1][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
 					},
 					filepath.Join("result-directory", "evaluation.log"): nil,
 					filepath.Join("result-directory", "golang-summed.csv"): func(t *testing.T, filePath, data string) {
 						actualAssessments := validateMetrics(t, extractMetricsCSVMatch, data, []metrics.Assessments{
 							metrics.Assessments{
-								metrics.AssessmentKeyCoverage:         10,
-								metrics.AssessmentKeyFilesExecuted:    1,
-								metrics.AssessmentKeyResponseNoError:  1,
-								metrics.AssessmentKeyResponseNoExcess: 1,
-								metrics.AssessmentKeyResponseWithCode: 1,
+								metrics.AssessmentKeyCoverage:         20,
+								metrics.AssessmentKeyFilesExecuted:    2,
+								metrics.AssessmentKeyResponseNoError:  2,
+								metrics.AssessmentKeyResponseNoExcess: 2,
+								metrics.AssessmentKeyResponseWithCode: 2,
 							},
-						}, []uint64{14})
+						}, []uint64{28})
 						// Assert non-deterministic behavior.
 						assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
-						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
-						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
+						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(508))
+						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(508))
 					},
 					filepath.Join("result-directory", "models-summed.csv"): func(t *testing.T, filePath, data string) {
 						actualAssessments := validateMetrics(t, extractMetricsCSVMatch, data, []metrics.Assessments{
 							metrics.Assessments{
-								metrics.AssessmentKeyCoverage:         10,
-								metrics.AssessmentKeyFilesExecuted:    1,
-								metrics.AssessmentKeyResponseNoError:  1,
-								metrics.AssessmentKeyResponseNoExcess: 1,
-								metrics.AssessmentKeyResponseWithCode: 1,
+								metrics.AssessmentKeyCoverage:         20,
+								metrics.AssessmentKeyFilesExecuted:    2,
+								metrics.AssessmentKeyResponseNoError:  2,
+								metrics.AssessmentKeyResponseNoExcess: 2,
+								metrics.AssessmentKeyResponseWithCode: 2,
 							},
-						}, []uint64{14})
+						}, []uint64{28})
 						// Assert non-deterministic behavior.
 						assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
-						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
-						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
+						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(508))
+						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(508))
 					},
 					filepath.Join("result-directory", "README.md"): func(t *testing.T, filePath, data string) {
 						validateReportLinks(t, data, []string{"symflower_symbolic-execution"})
@@ -473,7 +513,7 @@ func TestEvaluateExecute(t *testing.T) {
 				},
 
 				ExpectedOutputValidate: func(t *testing.T, output string, resultPath string) {
-					assert.Regexp(t, `Evaluation score for "symflower/symbolic-execution" \("code-no-excess"\): cost=0.00, score=14, coverage=10, files-executed=1, generate-tests-for-file-character-count=254, processing-time=\d+, response-character-count=254, response-no-error=1, response-no-excess=1, response-with-code=1`, output)
+					assert.Regexp(t, `Evaluation score for "symflower/symbolic-execution" \("code-no-excess"\): cost=0.00, score=28, coverage=20, files-executed=2, generate-tests-for-file-character-count=508, processing-time=\d+, response-character-count=508, response-no-error=2, response-no-excess=2, response-with-code=2`, output)
 					assert.Equal(t, 1, strings.Count(output, "Evaluation score for"))
 				},
 				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
@@ -489,42 +529,52 @@ func TestEvaluateExecute(t *testing.T) {
 								metrics.AssessmentKeyResponseNoExcess: 1,
 								metrics.AssessmentKeyResponseWithCode: 1,
 							},
-						}, []uint64{14})
+							metrics.Assessments{
+								metrics.AssessmentKeyCoverage:         10,
+								metrics.AssessmentKeyFilesExecuted:    1,
+								metrics.AssessmentKeyResponseNoError:  1,
+								metrics.AssessmentKeyResponseNoExcess: 1,
+								metrics.AssessmentKeyResponseWithCode: 1,
+							},
+						}, []uint64{14, 14})
 						// Assert non-deterministic behavior.
 						assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
 						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
 						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
+						assert.Greater(t, actualAssessments[1][metrics.AssessmentKeyProcessingTime], uint64(0))
+						assert.Equal(t, actualAssessments[1][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
+						assert.Equal(t, actualAssessments[1][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
 					},
 					filepath.Join("result-directory", "evaluation.log"): nil,
 					filepath.Join("result-directory", "golang-summed.csv"): func(t *testing.T, filePath, data string) {
 						actualAssessments := validateMetrics(t, extractMetricsCSVMatch, data, []metrics.Assessments{
 							metrics.Assessments{
-								metrics.AssessmentKeyCoverage:         10,
-								metrics.AssessmentKeyFilesExecuted:    1,
-								metrics.AssessmentKeyResponseNoError:  1,
-								metrics.AssessmentKeyResponseNoExcess: 1,
-								metrics.AssessmentKeyResponseWithCode: 1,
+								metrics.AssessmentKeyCoverage:         20,
+								metrics.AssessmentKeyFilesExecuted:    2,
+								metrics.AssessmentKeyResponseNoError:  2,
+								metrics.AssessmentKeyResponseNoExcess: 2,
+								metrics.AssessmentKeyResponseWithCode: 2,
 							},
-						}, []uint64{14})
+						}, []uint64{28})
 						// Assert non-deterministic behavior.
 						assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
-						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
-						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
+						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(508))
+						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(508))
 					},
 					filepath.Join("result-directory", "models-summed.csv"): func(t *testing.T, filePath, data string) {
 						actualAssessments := validateMetrics(t, extractMetricsCSVMatch, data, []metrics.Assessments{
 							metrics.Assessments{
-								metrics.AssessmentKeyCoverage:         10,
-								metrics.AssessmentKeyFilesExecuted:    1,
-								metrics.AssessmentKeyResponseNoError:  1,
-								metrics.AssessmentKeyResponseNoExcess: 1,
-								metrics.AssessmentKeyResponseWithCode: 1,
+								metrics.AssessmentKeyCoverage:         20,
+								metrics.AssessmentKeyFilesExecuted:    2,
+								metrics.AssessmentKeyResponseNoError:  2,
+								metrics.AssessmentKeyResponseNoExcess: 2,
+								metrics.AssessmentKeyResponseWithCode: 2,
 							},
-						}, []uint64{14})
+						}, []uint64{28})
 						// Assert non-deterministic behavior.
 						assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
-						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(254))
-						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(254))
+						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(508))
+						assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(508))
 					},
 					filepath.Join("result-directory", "README.md"): func(t *testing.T, filePath, data string) {
 						validateReportLinks(t, data, []string{"symflower_symbolic-execution"})
@@ -588,7 +638,7 @@ func TestEvaluateExecute(t *testing.T) {
 						filepath.Join("result-directory", "evaluation.log"): func(t *testing.T, filePath, data string) {
 							// Since the model is non-deterministic, we can only assert that the model did at least not error.
 							assert.Contains(t, data, fmt.Sprintf(`Evaluation score for "ollama/%s"`, providertesting.OllamaTestModel))
-							assert.Contains(t, data, "response-no-error=1")
+							assert.Contains(t, data, "response-no-error=2")
 							assert.Contains(t, data, "preloading model")
 							assert.Contains(t, data, "unloading model")
 						},
@@ -638,7 +688,7 @@ func TestEvaluateExecute(t *testing.T) {
 						filepath.Join("result-directory", "evaluation.log"): func(t *testing.T, filePath, data string) {
 							// Since the model is non-deterministic, we can only assert that the model did at least not error.
 							assert.Contains(t, data, fmt.Sprintf(`Evaluation score for "custom-ollama/%s"`, providertesting.OllamaTestModel))
-							assert.Contains(t, data, "response-no-error=1")
+							assert.Contains(t, data, "response-no-error=2")
 						},
 						filepath.Join("result-directory", "golang-summed.csv"): nil,
 						filepath.Join("result-directory", "models-summed.csv"): nil,
@@ -663,17 +713,17 @@ func TestEvaluateExecute(t *testing.T) {
 			ExpectedOutputValidate: func(t *testing.T, output string, resultPath string) {
 				actualAssessments := validateMetrics(t, extractMetricsLogsMatch, output, []metrics.Assessments{
 					metrics.Assessments{
-						metrics.AssessmentKeyCoverage:         30,
-						metrics.AssessmentKeyFilesExecuted:    3,
-						metrics.AssessmentKeyResponseNoError:  3,
-						metrics.AssessmentKeyResponseNoExcess: 3,
-						metrics.AssessmentKeyResponseWithCode: 3,
+						metrics.AssessmentKeyCoverage:         60,
+						metrics.AssessmentKeyFilesExecuted:    6,
+						metrics.AssessmentKeyResponseNoError:  6,
+						metrics.AssessmentKeyResponseNoExcess: 6,
+						metrics.AssessmentKeyResponseWithCode: 6,
 					},
-				}, []uint64{42})
+				}, []uint64{84})
 				// Assert non-deterministic behavior.
 				assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
-				assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(762))
-				assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(762))
+				assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(1524))
+				assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(1524))
 				assert.Equal(t, 1, strings.Count(output, "Evaluation score for"))
 			},
 			ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
@@ -687,11 +737,21 @@ func TestEvaluateExecute(t *testing.T) {
 							metrics.AssessmentKeyResponseNoExcess: 3,
 							metrics.AssessmentKeyResponseWithCode: 3,
 						},
-					}, []uint64{42})
+						metrics.Assessments{
+							metrics.AssessmentKeyCoverage:         30,
+							metrics.AssessmentKeyFilesExecuted:    3,
+							metrics.AssessmentKeyResponseNoError:  3,
+							metrics.AssessmentKeyResponseNoExcess: 3,
+							metrics.AssessmentKeyResponseWithCode: 3,
+						},
+					}, []uint64{42, 42})
 					// Assert non-deterministic behavior.
 					assert.Greater(t, actualAssessments[0][metrics.AssessmentKeyProcessingTime], uint64(0))
 					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(762))
 					assert.Equal(t, actualAssessments[0][metrics.AssessmentKeyResponseCharacterCount], uint64(762))
+					assert.Greater(t, actualAssessments[1][metrics.AssessmentKeyProcessingTime], uint64(0))
+					assert.Equal(t, actualAssessments[1][metrics.AssessmentKeyGenerateTestsForFileCharacterCount], uint64(762))
+					assert.Equal(t, actualAssessments[1][metrics.AssessmentKeyResponseCharacterCount], uint64(762))
 				},
 				filepath.Join("result-directory", "evaluation.log"): func(t *testing.T, filePath, data string) {
 					assert.Contains(t, data, "Run 1/3")

--- a/evaluate/evaluate.go
+++ b/evaluate/evaluate.go
@@ -126,7 +126,7 @@ func Evaluate(ctx *Context) (assessments *report.AssessmentStore, totalScore uin
 								}
 
 								assessment, ps, err := task.Run(temporaryRepository)
-								assessments.Add(model, language, repositoryPath, taskIdentifier, assessment)
+								assessments.AddAssessmentPerTask(model, language, repositoryPath, assessment)
 								if err != nil {
 									ps = append(ps, err)
 								}
@@ -226,7 +226,7 @@ func Evaluate(ctx *Context) (assessments *report.AssessmentStore, totalScore uin
 								}
 
 								assessment, ps, err := task.Run(temporaryRepository)
-								assessments.Add(model, language, repositoryPath, taskIdentifier, assessment)
+								assessments.AddAssessmentPerTask(model, language, repositoryPath, assessment)
 								problemsPerModel[modelID] = append(problemsPerModel[modelID], ps...)
 								if err != nil {
 									ctx.Log.Printf("ERROR: Model %q encountered a hard error for language %q, repository %q: %+v", modelID, languageID, repositoryPath, err)

--- a/evaluate/evaluate.go
+++ b/evaluate/evaluate.go
@@ -249,7 +249,8 @@ func Evaluate(ctx *Context) (assessments *report.AssessmentStore, totalScore uin
 		}
 	}
 	if isOnlyPlainRepositories {
-		totalScore = uint64(len(ctx.Languages)) * uint64(ctx.Runs)
+		// For every write-test task in the plain repository, each model is also executed with the `symflower fix` which results in double the total results.
+		totalScore = 2 * uint64(len(ctx.Languages)) * uint64(ctx.Runs)
 	}
 
 	return assessments, totalScore

--- a/evaluate/evaluate_test.go
+++ b/evaluate/evaluate_test.go
@@ -139,7 +139,7 @@ func TestEvaluate(t *testing.T) {
 				return nil
 			}))
 
-			assert.Equal(t, tc.ExpectedAssessments, actualAssessments)
+			assert.ElementsMatch(t, tc.ExpectedAssessments, actualAssessments)
 			assert.Equal(t, tc.ExpectedTotalScore, actualTotalScore)
 
 			if tc.ExpectedOutputValidate != nil {
@@ -200,8 +200,15 @@ func TestEvaluate(t *testing.T) {
 					Task:           evaluatetask.IdentifierWriteTests,
 					Assessment:     metrics.Assessments{},
 				},
+				&metricstesting.AssessmentTuple{
+					Model:          mockedModel,
+					Language:       languageGolang,
+					RepositoryPath: repositoryPath,
+					Task:           evaluatetask.IdentifierWriteTestsSymflowerFix,
+					Assessment:     metrics.Assessments{},
+				},
 			},
-			ExpectedTotalScore: 1,
+			ExpectedTotalScore: 2,
 			ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
 				filepath.Join(string(evaluatetask.IdentifierWriteTests), mockedModel.ID(), "golang", "golang", "plain.log"): nil,
 			},
@@ -246,8 +253,15 @@ func TestEvaluate(t *testing.T) {
 						Task:           evaluatetask.IdentifierWriteTests,
 						Assessment:     metrics.Assessments{},
 					},
+					&metricstesting.AssessmentTuple{
+						Model:          mockedModel,
+						Language:       languageGolang,
+						RepositoryPath: repositoryPath,
+						Task:           evaluatetask.IdentifierWriteTestsSymflowerFix,
+						Assessment:     metrics.Assessments{},
+					},
 				},
-				ExpectedTotalScore: 1,
+				ExpectedTotalScore: 2,
 				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
 					filepath.Join(string(evaluatetask.IdentifierWriteTests), evalmodel.CleanModelNameForFileSystem(mockedModelID), "golang", "golang", "plain.log"): func(t *testing.T, filePath, data string) {
 						assert.Contains(t, data, ErrEmptyResponseFromModel.Error())
@@ -301,8 +315,19 @@ func TestEvaluate(t *testing.T) {
 							metrics.AssessmentKeyResponseNoError:                    1,
 						},
 					},
+					&metricstesting.AssessmentTuple{
+						Model:          mockedModel,
+						Language:       languageGolang,
+						RepositoryPath: repositoryPath,
+						Task:           evaluatetask.IdentifierWriteTestsSymflowerFix,
+						Assessment: map[metrics.AssessmentKey]uint64{
+							metrics.AssessmentKeyGenerateTestsForFileCharacterCount: 14,
+							metrics.AssessmentKeyResponseCharacterCount:             14,
+							metrics.AssessmentKeyResponseNoError:                    1,
+						},
+					},
 				},
-				ExpectedTotalScore: 1,
+				ExpectedTotalScore: 2,
 				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
 					filepath.Join(string(evaluatetask.IdentifierWriteTests), evalmodel.CleanModelNameForFileSystem(mockedModelID), "golang", "golang", "plain.log"): func(t *testing.T, filePath, data string) {
 						assert.Contains(t, data, "Attempt 1/3: "+ErrEmptyResponseFromModel.Error())
@@ -355,8 +380,19 @@ func TestEvaluate(t *testing.T) {
 							metrics.AssessmentKeyResponseNoError:                    1,
 						},
 					},
+					&metricstesting.AssessmentTuple{
+						Model:          mockedModel,
+						Language:       languageGolang,
+						RepositoryPath: repositoryPath,
+						Task:           evaluatetask.IdentifierWriteTestsSymflowerFix,
+						Assessment: map[metrics.AssessmentKey]uint64{
+							metrics.AssessmentKeyGenerateTestsForFileCharacterCount: 14,
+							metrics.AssessmentKeyResponseCharacterCount:             14,
+							metrics.AssessmentKeyResponseNoError:                    1,
+						},
+					},
 				},
-				ExpectedTotalScore: 1,
+				ExpectedTotalScore: 2,
 				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
 					filepath.Join(string(evaluatetask.IdentifierWriteTests), evalmodel.CleanModelNameForFileSystem(mockedModelID), "golang", "golang", "plain.log"): func(t *testing.T, filePath, data string) {
 						assert.Contains(t, data, "DONE 0 tests, 1 error")
@@ -446,8 +482,30 @@ func TestEvaluate(t *testing.T) {
 					&metricstesting.AssessmentTuple{
 						Model:          mockedModel,
 						Language:       languageGolang,
+						RepositoryPath: repositoryNextPath,
+						Task:           evaluatetask.IdentifierWriteTestsSymflowerFix,
+						Assessment: map[metrics.AssessmentKey]uint64{
+							metrics.AssessmentKeyCoverage:        0,
+							metrics.AssessmentKeyFilesExecuted:   1,
+							metrics.AssessmentKeyResponseNoError: 1,
+						},
+					},
+					&metricstesting.AssessmentTuple{
+						Model:          mockedModel,
+						Language:       languageGolang,
 						RepositoryPath: repositoryPlainPath,
 						Task:           evaluatetask.IdentifierWriteTests,
+						Assessment: map[metrics.AssessmentKey]uint64{
+							metrics.AssessmentKeyCoverage:        0,
+							metrics.AssessmentKeyFilesExecuted:   2,
+							metrics.AssessmentKeyResponseNoError: 2,
+						},
+					},
+					&metricstesting.AssessmentTuple{
+						Model:          mockedModel,
+						Language:       languageGolang,
+						RepositoryPath: repositoryPlainPath,
+						Task:           evaluatetask.IdentifierWriteTestsSymflowerFix,
 						Assessment: map[metrics.AssessmentKey]uint64{
 							metrics.AssessmentKeyCoverage:        0,
 							metrics.AssessmentKeyFilesExecuted:   2,
@@ -519,8 +577,30 @@ func TestEvaluate(t *testing.T) {
 					&metricstesting.AssessmentTuple{
 						Model:          mockedModel,
 						Language:       languageGolang,
+						RepositoryPath: repositoryNextPath,
+						Task:           evaluatetask.IdentifierWriteTestsSymflowerFix,
+						Assessment: map[metrics.AssessmentKey]uint64{
+							metrics.AssessmentKeyCoverage:        0,
+							metrics.AssessmentKeyFilesExecuted:   2,
+							metrics.AssessmentKeyResponseNoError: 2,
+						},
+					},
+					&metricstesting.AssessmentTuple{
+						Model:          mockedModel,
+						Language:       languageGolang,
 						RepositoryPath: repositoryPlainPath,
 						Task:           evaluatetask.IdentifierWriteTests,
+						Assessment: map[metrics.AssessmentKey]uint64{
+							metrics.AssessmentKeyCoverage:        0,
+							metrics.AssessmentKeyFilesExecuted:   1,
+							metrics.AssessmentKeyResponseNoError: 1,
+						},
+					},
+					&metricstesting.AssessmentTuple{
+						Model:          mockedModel,
+						Language:       languageGolang,
+						RepositoryPath: repositoryPlainPath,
+						Task:           evaluatetask.IdentifierWriteTestsSymflowerFix,
 						Assessment: map[metrics.AssessmentKey]uint64{
 							metrics.AssessmentKeyCoverage:        0,
 							metrics.AssessmentKeyFilesExecuted:   1,
@@ -581,6 +661,13 @@ func TestEvaluate(t *testing.T) {
 						Task:           evaluatetask.IdentifierWriteTests,
 						Assessment:     map[metrics.AssessmentKey]uint64{},
 					},
+					&metricstesting.AssessmentTuple{
+						Model:          mockedModel,
+						Language:       languageGolang,
+						RepositoryPath: repositoryPlainPath,
+						Task:           evaluatetask.IdentifierWriteTestsSymflowerFix,
+						Assessment:     map[metrics.AssessmentKey]uint64{},
+					},
 				},
 				ExpectedTotalScore: 0,
 				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
@@ -634,8 +721,19 @@ func TestEvaluate(t *testing.T) {
 							metrics.AssessmentKeyResponseNoError: 3,
 						},
 					},
+					&metricstesting.AssessmentTuple{
+						Model:          mockedModel,
+						Language:       languageGolang,
+						RepositoryPath: repositoryPath,
+						Task:           evaluatetask.IdentifierWriteTestsSymflowerFix,
+						Assessment: map[metrics.AssessmentKey]uint64{
+							metrics.AssessmentKeyCoverage:        0,
+							metrics.AssessmentKeyFilesExecuted:   3,
+							metrics.AssessmentKeyResponseNoError: 3,
+						},
+					},
 				},
-				ExpectedTotalScore: 3,
+				ExpectedTotalScore: 6,
 				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
 					filepath.Join(string(evaluatetask.IdentifierWriteTests), evalmodel.CleanModelNameForFileSystem(mockedModelID), "golang", "golang", "plain.log"): nil,
 				},
@@ -690,8 +788,19 @@ func TestEvaluate(t *testing.T) {
 							metrics.AssessmentKeyResponseNoError: 3,
 						},
 					},
+					&metricstesting.AssessmentTuple{
+						Model:          mockedModel,
+						Language:       languageGolang,
+						RepositoryPath: repositoryPath,
+						Task:           evaluatetask.IdentifierWriteTestsSymflowerFix,
+						Assessment: map[metrics.AssessmentKey]uint64{
+							metrics.AssessmentKeyCoverage:        0,
+							metrics.AssessmentKeyFilesExecuted:   3,
+							metrics.AssessmentKeyResponseNoError: 3,
+						},
+					},
 				},
-				ExpectedTotalScore: 3,
+				ExpectedTotalScore: 6,
 				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
 					filepath.Join(string(evaluatetask.IdentifierWriteTests), evalmodel.CleanModelNameForFileSystem(mockedModelID), "golang", "golang", "plain.log"): nil,
 				},
@@ -776,8 +885,19 @@ func TestEvaluate(t *testing.T) {
 							metrics.AssessmentKeyResponseNoError: 3,
 						},
 					},
+					&metricstesting.AssessmentTuple{
+						Model:          mockedModel,
+						Language:       languageGolang,
+						RepositoryPath: repositoryPath,
+						Task:           evaluatetask.IdentifierWriteTestsSymflowerFix,
+						Assessment: map[metrics.AssessmentKey]uint64{
+							metrics.AssessmentKeyCoverage:        0,
+							metrics.AssessmentKeyFilesExecuted:   3,
+							metrics.AssessmentKeyResponseNoError: 3,
+						},
+					},
 				},
-				ExpectedTotalScore: 3,
+				ExpectedTotalScore: 6,
 				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
 					filepath.Join(string(evaluatetask.IdentifierWriteTests), evalmodel.CleanModelNameForFileSystem(mockedModelID), "golang", "golang", "plain.log"): nil,
 				},
@@ -845,8 +965,19 @@ func TestEvaluate(t *testing.T) {
 							metrics.AssessmentKeyResponseNoError: 3,
 						},
 					},
+					&metricstesting.AssessmentTuple{
+						Model:          mockedModel,
+						Language:       languageGolang,
+						RepositoryPath: repositoryPath,
+						Task:           evaluatetask.IdentifierWriteTestsSymflowerFix,
+						Assessment: map[metrics.AssessmentKey]uint64{
+							metrics.AssessmentKeyCoverage:        0,
+							metrics.AssessmentKeyFilesExecuted:   3,
+							metrics.AssessmentKeyResponseNoError: 3,
+						},
+					},
 				},
-				ExpectedTotalScore: 3,
+				ExpectedTotalScore: 6,
 				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
 					filepath.Join(string(evaluatetask.IdentifierWriteTests), evalmodel.CleanModelNameForFileSystem(mockedModelID), "golang", "golang", "plain.log"): nil,
 				},
@@ -895,8 +1026,19 @@ func TestEvaluate(t *testing.T) {
 						metrics.AssessmentKeyResponseNoError: 1,
 					},
 				},
+				&metricstesting.AssessmentTuple{
+					Model:          mockedModel,
+					Language:       languageGolang,
+					RepositoryPath: repositoryPath,
+					Task:           evaluatetask.IdentifierWriteTestsSymflowerFix,
+					Assessment: map[metrics.AssessmentKey]uint64{
+						metrics.AssessmentKeyCoverage:        0,
+						metrics.AssessmentKeyFilesExecuted:   1,
+						metrics.AssessmentKeyResponseNoError: 1,
+					},
+				},
 			},
-			ExpectedTotalScore: 1,
+			ExpectedTotalScore: 2,
 			ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
 				filepath.Join(string(evaluatetask.IdentifierWriteTests), evalmodel.CleanModelNameForFileSystem(mockedModelID), "golang", "golang", "plain.log"): nil,
 			},

--- a/evaluate/metrics/assessment.go
+++ b/evaluate/metrics/assessment.go
@@ -152,3 +152,19 @@ func (a Assessments) StringCSV() (row []string) {
 
 	return row
 }
+
+// CombineWithSymflowerFixAssessments combines the model assessments with the ones from "symflower fix".
+func CombineWithSymflowerFixAssessments(model Assessments, fixed Assessments) (combined Assessments) {
+	combined = NewAssessments()
+
+	combined[AssessmentKeyCoverage] = fixed[AssessmentKeyCoverage]
+	combined[AssessmentKeyFilesExecuted] = fixed[AssessmentKeyFilesExecuted]
+	combined[AssessmentKeyGenerateTestsForFileCharacterCount] = model[AssessmentKeyGenerateTestsForFileCharacterCount]
+	combined[AssessmentKeyProcessingTime] = model[AssessmentKeyProcessingTime] + fixed[AssessmentKeyProcessingTime]
+	combined[AssessmentKeyResponseCharacterCount] = model[AssessmentKeyResponseCharacterCount]
+	combined[AssessmentKeyResponseNoError] = model[AssessmentKeyResponseNoError]
+	combined[AssessmentKeyResponseNoExcess] = model[AssessmentKeyResponseNoExcess]
+	combined[AssessmentKeyResponseWithCode] = model[AssessmentKeyResponseWithCode]
+
+	return combined
+}

--- a/evaluate/metrics/assessment_test.go
+++ b/evaluate/metrics/assessment_test.go
@@ -272,3 +272,54 @@ func TestAssessmentsScore(t *testing.T) {
 		ExpectedScore: uint64(9),
 	})
 }
+
+func TestCombineModelAndSymflowerFixAssessments(t *testing.T) {
+	type testCase struct {
+		Name string
+
+		ModelAssessment         Assessments
+		SymflowerFixAssessments Assessments
+
+		ExpectedAssessments Assessments
+	}
+
+	validate := func(t *testing.T, tc *testCase) {
+		t.Run(tc.Name, func(t *testing.T) {
+			actualAssessments := CombineWithSymflowerFixAssessments(tc.ModelAssessment, tc.SymflowerFixAssessments)
+
+			assert.Equal(t, tc.ExpectedAssessments, actualAssessments)
+		})
+	}
+
+	validate(t, &testCase{
+		Name: "Simple",
+
+		ModelAssessment: Assessments{
+			AssessmentKeyFilesExecuted:                      1,
+			AssessmentKeyProcessingTime:                     uint64(200),
+			AssessmentKeyCoverage:                           0,
+			AssessmentKeyResponseCharacterCount:             100,
+			AssessmentKeyGenerateTestsForFileCharacterCount: 50,
+			AssessmentKeyResponseNoError:                    0,
+			AssessmentKeyResponseWithCode:                   1,
+			AssessmentKeyResponseNoExcess:                   1,
+		},
+		SymflowerFixAssessments: Assessments{
+			AssessmentKeyFilesExecuted:   1,
+			AssessmentKeyProcessingTime:  uint64(100),
+			AssessmentKeyCoverage:        10,
+			AssessmentKeyResponseNoError: 1,
+		},
+
+		ExpectedAssessments: Assessments{
+			AssessmentKeyFilesExecuted:                      1,
+			AssessmentKeyProcessingTime:                     uint64(300),
+			AssessmentKeyCoverage:                           10,
+			AssessmentKeyResponseCharacterCount:             100,
+			AssessmentKeyGenerateTestsForFileCharacterCount: 50,
+			AssessmentKeyResponseNoError:                    0,
+			AssessmentKeyResponseWithCode:                   1,
+			AssessmentKeyResponseNoExcess:                   1,
+		},
+	})
+}

--- a/evaluate/report/collection.go
+++ b/evaluate/report/collection.go
@@ -84,6 +84,13 @@ func (a *AssessmentStore) Add(model model.Model, l language.Language, repository
 	assessments.Add(assessment)
 }
 
+// AddAssessmentPerTask adds new assessments per task.
+func (a *AssessmentStore) AddAssessmentPerTask(model model.Model, l language.Language, repositoryPath string, taskAssessment map[task.Identifier]metrics.Assessments) {
+	for taskIdentifier, assessment := range taskAssessment {
+		a.Add(model, l, repositoryPath, taskIdentifier, assessment)
+	}
+}
+
 // Walk walks over all entries.
 func (a *AssessmentStore) Walk(function func(m model.Model, l language.Language, r string, t task.Identifier, a metrics.Assessments) error) (err error) {
 	models := maps.Keys(a.store)

--- a/evaluate/task/symflower-fix.go
+++ b/evaluate/task/symflower-fix.go
@@ -1,0 +1,32 @@
+package task
+
+import (
+	"context"
+	"time"
+
+	pkgerrors "github.com/pkg/errors"
+	"github.com/symflower/eval-dev-quality/evaluate/metrics"
+	"github.com/symflower/eval-dev-quality/language"
+	"github.com/symflower/eval-dev-quality/log"
+	"github.com/symflower/eval-dev-quality/tools"
+	"github.com/symflower/eval-dev-quality/util"
+)
+
+// symflowerFix runs the "symflower fix" command and returns its execution time in milliseconds.
+func symflowerFix(logger *log.Logger, modelAssessment metrics.Assessments, repositoryPath string, language language.Language) (duration uint64, err error) {
+	start := time.Now()
+	_, err = util.CommandWithResult(context.Background(), logger, &util.Command{
+		Command: []string{
+			tools.SymflowerPath, "fix",
+			"--language", language.ID(),
+			"--workspace", repositoryPath,
+		},
+
+		Directory: repositoryPath,
+	})
+	if err != nil {
+		return 0, pkgerrors.WithStack(err)
+	}
+
+	return uint64(time.Since(start).Milliseconds()), nil
+}

--- a/evaluate/task/task-code-repair_test.go
+++ b/evaluate/task/task-code-repair_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/symflower/eval-dev-quality/language/java"
 	"github.com/symflower/eval-dev-quality/log"
 	modeltesting "github.com/symflower/eval-dev-quality/model/testing"
+	"github.com/symflower/eval-dev-quality/task"
 	"github.com/zimmski/osutil"
 	"github.com/zimmski/osutil/bytesutil"
 )
@@ -71,10 +72,12 @@ func TestTaskCodeRepairRun(t *testing.T) {
 				TestDataPath:   temporaryDirectoryPath,
 				RepositoryPath: filepath.Join("golang", "mistakes"),
 
-				ExpectedRepositoryAssessment: metrics.Assessments{
-					metrics.AssessmentKeyCoverage:        30,
-					metrics.AssessmentKeyFilesExecuted:   1,
-					metrics.AssessmentKeyResponseNoError: 1,
+				ExpectedRepositoryAssessment: map[task.Identifier]metrics.Assessments{
+					IdentifierCodeRepair: metrics.Assessments{
+						metrics.AssessmentKeyCoverage:        30,
+						metrics.AssessmentKeyFilesExecuted:   1,
+						metrics.AssessmentKeyResponseNoError: 1,
+					},
 				},
 				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
 					filepath.Join(string(IdentifierCodeRepair), "mocked-model", "golang", "golang", "mistakes.log"): func(t *testing.T, filePath, data string) {
@@ -134,10 +137,12 @@ func TestTaskCodeRepairRun(t *testing.T) {
 				TestDataPath:   temporaryDirectoryPath,
 				RepositoryPath: filepath.Join("golang", "mistakes"),
 
-				ExpectedRepositoryAssessment: metrics.Assessments{
-					metrics.AssessmentKeyCoverage:        60,
-					metrics.AssessmentKeyFilesExecuted:   2,
-					metrics.AssessmentKeyResponseNoError: 2,
+				ExpectedRepositoryAssessment: map[task.Identifier]metrics.Assessments{
+					IdentifierCodeRepair: metrics.Assessments{
+						metrics.AssessmentKeyCoverage:        60,
+						metrics.AssessmentKeyFilesExecuted:   2,
+						metrics.AssessmentKeyResponseNoError: 2,
+					},
 				},
 				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
 					filepath.Join(string(IdentifierCodeRepair), "mocked-model", "golang", "golang", "mistakes.log"): func(t *testing.T, filePath, data string) {
@@ -188,10 +193,12 @@ func TestTaskCodeRepairRun(t *testing.T) {
 				TestDataPath:   temporaryDirectoryPath,
 				RepositoryPath: filepath.Join("java", "mistakes"),
 
-				ExpectedRepositoryAssessment: metrics.Assessments{
-					metrics.AssessmentKeyCoverage:        80,
-					metrics.AssessmentKeyFilesExecuted:   1,
-					metrics.AssessmentKeyResponseNoError: 1,
+				ExpectedRepositoryAssessment: map[task.Identifier]metrics.Assessments{
+					IdentifierCodeRepair: metrics.Assessments{
+						metrics.AssessmentKeyCoverage:        80,
+						metrics.AssessmentKeyFilesExecuted:   1,
+						metrics.AssessmentKeyResponseNoError: 1,
+					},
 				},
 				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
 					filepath.Join(string(IdentifierCodeRepair), "mocked-model", "java", "java", "mistakes.log"): func(t *testing.T, filePath, data string) {
@@ -253,10 +260,12 @@ func TestTaskCodeRepairRun(t *testing.T) {
 				TestDataPath:   temporaryDirectoryPath,
 				RepositoryPath: filepath.Join("java", "mistakes"),
 
-				ExpectedRepositoryAssessment: metrics.Assessments{
-					metrics.AssessmentKeyCoverage:        160,
-					metrics.AssessmentKeyFilesExecuted:   2,
-					metrics.AssessmentKeyResponseNoError: 2,
+				ExpectedRepositoryAssessment: map[task.Identifier]metrics.Assessments{
+					IdentifierCodeRepair: metrics.Assessments{
+						metrics.AssessmentKeyCoverage:        160,
+						metrics.AssessmentKeyFilesExecuted:   2,
+						metrics.AssessmentKeyResponseNoError: 2,
+					},
 				},
 				ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
 					filepath.Join(string(IdentifierCodeRepair), "mocked-model", "java", "java", "mistakes.log"): func(t *testing.T, filePath, data string) {

--- a/evaluate/task/task-write-test.go
+++ b/evaluate/task/task-write-test.go
@@ -63,7 +63,11 @@ func (t *TaskWriteTests) Run(repository evaltask.Repository) (repositoryAssessme
 	}
 
 	modelAssessment := metrics.NewAssessments()
+	withSymflowerAssessment := metrics.NewAssessments()
 	for _, filePath := range filePaths {
+		modelAssessmentForFile := metrics.NewAssessments()
+		withSymflowerAssessmentForFile := modelAssessmentForFile // The symflower assessment tracks how the model result can be improved in case of a failure, so just link to the model assessment until a failure actually happens.
+
 		if err := repository.Reset(t.Logger); err != nil {
 			t.Logger.Panicf("ERROR: unable to reset temporary repository path: %s", err)
 		}
@@ -85,23 +89,61 @@ func (t *TaskWriteTests) Run(repository evaltask.Repository) (repositoryAssessme
 		if assessments[metrics.AssessmentKeyProcessingTime] == 0 {
 			return nil, nil, pkgerrors.Errorf("no model response time measurement present for %q at repository %q", t.Model.ID(), repository.Name())
 		}
-		modelAssessment.Add(assessments)
-		modelAssessment.Award(metrics.AssessmentKeyResponseNoError)
+		modelAssessmentForFile.Add(assessments)
+		modelAssessmentForFile.Award(metrics.AssessmentKeyResponseNoError)
 
 		coverage, ps, err := t.Language.Execute(log, dataPath)
 		problems = append(problems, ps...)
 		if err != nil {
 			problems = append(problems, pkgerrors.WithMessage(err, filePath))
 
-			continue
+			// Run "symflower fix"  if the model response fails to execute.
+			if t.Language.ID() == "golang" { // Currently we only support Go for "symflower fix".
+				log.Print("model response alone failed execution, attempting to fix with \"symflower fix \"")
+
+				duration, err := symflowerFix(log, modelAssessment, dataPath, t.Language)
+				if err != nil {
+					problems = append(problems, err)
+
+					modelAssessment.Add(modelAssessmentForFile)
+					withSymflowerAssessment.Add(withSymflowerAssessmentForFile)
+
+					continue
+				}
+
+				coverage, ps, err := t.Language.Execute(log, dataPath)
+				problems = append(problems, ps...)
+				if err != nil {
+					problems = append(problems, pkgerrors.WithMessage(err, "symflower fix"))
+
+					modelAssessment.Add(modelAssessmentForFile)
+					withSymflowerAssessment.Add(withSymflowerAssessmentForFile)
+
+					continue
+				}
+				log.Printf("with symflower repair: Executes tests with %d coverage objects", coverage)
+
+				// Symflower was able to fix a failure so now update the assessment with the improved results.
+				withSymflowerAssessmentForFile = metrics.NewAssessments()
+				withSymflowerAssessmentForFile[metrics.AssessmentKeyProcessingTime] = duration
+				withSymflowerAssessmentForFile.Award(metrics.AssessmentKeyFilesExecuted)
+				withSymflowerAssessmentForFile.AwardPoints(metrics.AssessmentKeyCoverage, coverage)
+
+				withSymflowerAssessmentForFile = metrics.CombineWithSymflowerFixAssessments(modelAssessmentForFile, withSymflowerAssessmentForFile)
+			}
+		} else {
+			log.Printf("Executes tests with %d coverage objects", coverage)
+			modelAssessmentForFile.Award(metrics.AssessmentKeyFilesExecuted)
+			modelAssessmentForFile.AwardPoints(metrics.AssessmentKeyCoverage, coverage)
 		}
-		log.Printf("Executes tests with %d coverage objects", coverage)
-		modelAssessment.Award(metrics.AssessmentKeyFilesExecuted)
-		modelAssessment.AwardPoints(metrics.AssessmentKeyCoverage, coverage)
+
+		modelAssessment.Add(modelAssessmentForFile)
+		withSymflowerAssessment.Add(withSymflowerAssessmentForFile)
 	}
 
 	repositoryAssessment = map[evaltask.Identifier]metrics.Assessments{
-		IdentifierWriteTests: modelAssessment,
+		IdentifierWriteTests:             modelAssessment,
+		IdentifierWriteTestsSymflowerFix: withSymflowerAssessment,
 	}
 
 	return repositoryAssessment, problems, nil

--- a/evaluate/task/task-write-test_test.go
+++ b/evaluate/task/task-write-test_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/symflower/eval-dev-quality/log"
 	modeltesting "github.com/symflower/eval-dev-quality/model/testing"
 	"github.com/symflower/eval-dev-quality/task"
+	"github.com/zimmski/osutil"
+	"github.com/zimmski/osutil/bytesutil"
 )
 
 func TestTaskWriteTestsRun(t *testing.T) {
@@ -65,9 +67,14 @@ func TestTaskWriteTestsRun(t *testing.T) {
 					metrics.AssessmentKeyFilesExecuted:   1,
 					metrics.AssessmentKeyResponseNoError: 2,
 				},
+				IdentifierWriteTestsSymflowerFix: metrics.Assessments{
+					metrics.AssessmentKeyFilesExecuted:   1,
+					metrics.AssessmentKeyResponseNoError: 2,
+				},
 			},
 			ExpectedProblemContains: []string{
 				"expected 'package', found does",
+				"exit status 1",
 			},
 			ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
 				filepath.Join(string(IdentifierWriteTests), "mocked-model", "golang", "golang", "plain.log"): func(t *testing.T, filePath, data string) {
@@ -75,6 +82,108 @@ func TestTaskWriteTestsRun(t *testing.T) {
 					assert.Contains(t, data, "PASS: TestTaskB")
 				},
 			},
+		})
+	})
+
+	t.Run("Symflower Fix", func(t *testing.T) {
+		t.Run("Go", func(t *testing.T) {
+			validateGo := func(t *testing.T, testName string, testFileContent string, expectedAssessments map[task.Identifier]metrics.Assessments, expectedProblems []string, assertTestsPass bool) {
+				temporaryDirectoryPath := t.TempDir()
+				repositoryPath := filepath.Join(temporaryDirectoryPath, "golang", "plain")
+				require.NoError(t, osutil.CopyTree(filepath.Join("..", "..", "testdata", "golang", "plain"), repositoryPath))
+
+				modelMock := modeltesting.NewMockModelNamed(t, "mocked-model")
+				modelMock.RegisterGenerateSuccess(t, IdentifierWriteTests, "plain_test.go", testFileContent, metricstesting.AssessmentsWithProcessingTime).Once()
+
+				validate(t, &tasktesting.TestCaseTask{
+					Name: testName,
+
+					Model:          modelMock,
+					Language:       &golang.Language{},
+					TestDataPath:   temporaryDirectoryPath,
+					RepositoryPath: filepath.Join("golang", "plain"),
+
+					ExpectedRepositoryAssessment: expectedAssessments,
+					ExpectedProblemContains:      expectedProblems,
+					ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
+						filepath.Join(string(IdentifierWriteTests), "mocked-model", "golang", "golang", "plain.log"): func(t *testing.T, filePath, data string) {
+							assert.Contains(t, data, "Evaluating model \"mocked-model\"")
+							if assertTestsPass {
+								assert.Contains(t, data, "PASS: TestPlain")
+							}
+						},
+					},
+				})
+			}
+			{
+				expectedAssessments := map[task.Identifier]metrics.Assessments{
+					IdentifierWriteTests: metrics.Assessments{
+						metrics.AssessmentKeyFilesExecuted:   1,
+						metrics.AssessmentKeyResponseNoError: 1,
+						metrics.AssessmentKeyCoverage:        10,
+					},
+					IdentifierWriteTestsSymflowerFix: metrics.Assessments{
+						metrics.AssessmentKeyFilesExecuted:   1,
+						metrics.AssessmentKeyResponseNoError: 1,
+						metrics.AssessmentKeyCoverage:        10,
+					},
+				}
+				validateGo(t, "Model generated correct test", bytesutil.StringTrimIndentations(`
+					package plain
+
+					import "testing"
+
+					func TestPlain(t *testing.T) {
+						   plain()
+					}
+				`), expectedAssessments, nil, true)
+			}
+			{
+				expectedAssessments := map[task.Identifier]metrics.Assessments{
+					IdentifierWriteTests: metrics.Assessments{
+						metrics.AssessmentKeyResponseNoError: 1,
+					},
+					IdentifierWriteTestsSymflowerFix: metrics.Assessments{
+						metrics.AssessmentKeyFilesExecuted:   1,
+						metrics.AssessmentKeyResponseNoError: 1,
+						metrics.AssessmentKeyCoverage:        10,
+					},
+				}
+				expectedProblems := []string{
+					"imported and not used",
+				}
+				validateGo(t, "Model generated test with unused import", bytesutil.StringTrimIndentations(`
+					package plain
+
+					import (
+						"testing"
+						"strings"
+					)
+
+					func TestPlain(t *testing.T) {
+					   	plain()
+					}
+				`), expectedAssessments, expectedProblems, true)
+			}
+			{
+				expectedAssessments := map[task.Identifier]metrics.Assessments{
+					IdentifierWriteTests: metrics.Assessments{
+						metrics.AssessmentKeyResponseNoError: 1,
+					},
+					IdentifierWriteTestsSymflowerFix: metrics.Assessments{
+						metrics.AssessmentKeyResponseNoError: 1,
+					},
+				}
+				expectedProblems := []string{
+					"expected declaration, found this",
+					"unable to format source code",
+				}
+				validateGo(t, "Model generated test that is unfixable", bytesutil.StringTrimIndentations(`
+					package plain
+
+					this is not valid go code
+				`), expectedAssessments, expectedProblems, false)
+			}
 		})
 	})
 }

--- a/evaluate/task/task-write-test_test.go
+++ b/evaluate/task/task-write-test_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/symflower/eval-dev-quality/language/golang"
 	"github.com/symflower/eval-dev-quality/log"
 	modeltesting "github.com/symflower/eval-dev-quality/model/testing"
+	"github.com/symflower/eval-dev-quality/task"
 )
 
 func TestTaskWriteTestsRun(t *testing.T) {
@@ -59,9 +60,11 @@ func TestTaskWriteTestsRun(t *testing.T) {
 			TestDataPath:   temporaryDirectoryPath,
 			RepositoryPath: filepath.Join("golang", "plain"),
 
-			ExpectedRepositoryAssessment: metrics.Assessments{
-				metrics.AssessmentKeyFilesExecuted:   1,
-				metrics.AssessmentKeyResponseNoError: 2,
+			ExpectedRepositoryAssessment: map[task.Identifier]metrics.Assessments{
+				IdentifierWriteTests: metrics.Assessments{
+					metrics.AssessmentKeyFilesExecuted:   1,
+					metrics.AssessmentKeyResponseNoError: 2,
+				},
 			},
 			ExpectedProblemContains: []string{
 				"expected 'package', found does",

--- a/evaluate/task/task.go
+++ b/evaluate/task/task.go
@@ -33,6 +33,8 @@ func registerIdentifier(name string) (identifier evaltask.Identifier) {
 var (
 	// IdentifierWriteTests holds the identifier for the "write test" task.
 	IdentifierWriteTests = registerIdentifier("write-tests")
+	// IdentifierWriteTestsSymflowerFix holds the identifier for the "write test" task with the "symflower fix" applied.
+	IdentifierWriteTestsSymflowerFix = registerIdentifier("write-tests-symflower-fix")
 	// IdentifierCodeRepair holds the identifier for the "code repair" task.
 	IdentifierCodeRepair = registerIdentifier("code-repair")
 )

--- a/evaluate/task/test-integration/task_test.go
+++ b/evaluate/task/test-integration/task_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/symflower/eval-dev-quality/language/golang"
 	"github.com/symflower/eval-dev-quality/log"
 	"github.com/symflower/eval-dev-quality/model/symflower"
+	"github.com/symflower/eval-dev-quality/task"
 	"github.com/symflower/eval-dev-quality/tools"
 	toolstesting "github.com/symflower/eval-dev-quality/tools/testing"
 )
@@ -48,14 +49,16 @@ func TestTaskWriteTestsRun(t *testing.T) {
 		TestDataPath:   filepath.Join("..", "..", "..", "testdata"),
 		RepositoryPath: filepath.Join("golang", "plain"),
 
-		ExpectedRepositoryAssessment: metrics.Assessments{
-			metrics.AssessmentKeyGenerateTestsForFileCharacterCount: 254,
-			metrics.AssessmentKeyResponseCharacterCount:             254,
-			metrics.AssessmentKeyCoverage:                           10,
-			metrics.AssessmentKeyFilesExecuted:                      1,
-			metrics.AssessmentKeyResponseNoError:                    1,
-			metrics.AssessmentKeyResponseNoExcess:                   1,
-			metrics.AssessmentKeyResponseWithCode:                   1,
+		ExpectedRepositoryAssessment: map[task.Identifier]metrics.Assessments{
+			evaluatetask.IdentifierWriteTests: metrics.Assessments{
+				metrics.AssessmentKeyGenerateTestsForFileCharacterCount: 254,
+				metrics.AssessmentKeyResponseCharacterCount:             254,
+				metrics.AssessmentKeyCoverage:                           10,
+				metrics.AssessmentKeyFilesExecuted:                      1,
+				metrics.AssessmentKeyResponseNoError:                    1,
+				metrics.AssessmentKeyResponseNoExcess:                   1,
+				metrics.AssessmentKeyResponseWithCode:                   1,
+			},
 		},
 		ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
 			filepath.Join(string(evaluatetask.IdentifierWriteTests), "symflower_symbolic-execution", "golang", "golang", "plain.log"): func(t *testing.T, filePath, data string) {

--- a/evaluate/task/test-integration/task_test.go
+++ b/evaluate/task/test-integration/task_test.go
@@ -59,6 +59,15 @@ func TestTaskWriteTestsRun(t *testing.T) {
 				metrics.AssessmentKeyResponseNoExcess:                   1,
 				metrics.AssessmentKeyResponseWithCode:                   1,
 			},
+			evaluatetask.IdentifierWriteTestsSymflowerFix: metrics.Assessments{
+				metrics.AssessmentKeyGenerateTestsForFileCharacterCount: 254,
+				metrics.AssessmentKeyResponseCharacterCount:             254,
+				metrics.AssessmentKeyCoverage:                           10,
+				metrics.AssessmentKeyFilesExecuted:                      1,
+				metrics.AssessmentKeyResponseNoError:                    1,
+				metrics.AssessmentKeyResponseNoExcess:                   1,
+				metrics.AssessmentKeyResponseWithCode:                   1,
+			},
 		},
 		ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
 			filepath.Join(string(evaluatetask.IdentifierWriteTests), "symflower_symbolic-execution", "golang", "golang", "plain.log"): func(t *testing.T, filePath, data string) {

--- a/evaluate/task/testing/task.go
+++ b/evaluate/task/testing/task.go
@@ -24,7 +24,7 @@ type TestCaseTask struct {
 	TestDataPath   string
 	RepositoryPath string
 
-	ExpectedRepositoryAssessment metrics.Assessments
+	ExpectedRepositoryAssessment map[evaltask.Identifier]metrics.Assessments
 	ExpectedResultFiles          map[string]func(t *testing.T, filePath string, data string)
 	ExpectedProblemContains      []string
 	ExpectedError                error
@@ -33,7 +33,7 @@ type TestCaseTask struct {
 func (tc *TestCaseTask) Validate(t *testing.T, task evaltask.Task, repository evaltask.Repository, resultPath string) {
 	actualRepositoryAssessment, actualProblems, actualErr := task.Run(repository)
 
-	metricstesting.AssertAssessmentsEqual(t, tc.ExpectedRepositoryAssessment, actualRepositoryAssessment)
+	metricstesting.AssertTaskAssessmentsEqual(t, tc.ExpectedRepositoryAssessment, actualRepositoryAssessment)
 	if assert.Equal(t, len(tc.ExpectedProblemContains), len(actualProblems), "problems count") {
 		for i, expectedProblem := range tc.ExpectedProblemContains {
 			actualProblem := actualProblems[i]

--- a/task/task.go
+++ b/task/task.go
@@ -39,7 +39,7 @@ type Task interface {
 	Identifier() (identifier Identifier)
 
 	// Run runs a task in a given repository.
-	Run(repository Repository) (assessments metrics.Assessments, problems []error, err error)
+	Run(repository Repository) (assessments map[Identifier]metrics.Assessments, problems []error, err error)
 }
 
 // Repository defines a repository to be evaluated.

--- a/tools/symflower.go
+++ b/tools/symflower.go
@@ -91,7 +91,7 @@ func (*symflower) CheckVersion(logger *log.Logger, binaryPath string) (err error
 }
 
 // SymflowerVersionRequired holds the version of Symflower required for this revision of the evaluation.
-const SymflowerVersionRequired = "37153"
+const SymflowerVersionRequired = "38036"
 
 // RequiredVersion returns the required version of the tool.
 func (*symflower) RequiredVersion() string {


### PR DESCRIPTION
Part of #213 