### PR TITLE
Change the "code-repair" and "write-tests" task prompt to enforce the generated code to be inside code fences, to ensure we can extract the code from the LLMs response

### DIFF
--- a/model/llm/llm.go
+++ b/model/llm/llm.go
@@ -108,7 +108,7 @@ type llmCodeRepairSourceFilePromptContext struct {
 // llmCodeRepairSourceFilePromptTemplate is the template for generating an LLM code repair prompt.
 var llmCodeRepairSourceFilePromptTemplate = template.Must(template.New("model-llm-code-repair-source-file-prompt").Parse(bytesutil.StringTrimIndentations(`
 	Given the following {{ .Language.Name }} code file "{{ .FilePath }}" with package "{{ .ImportPath }}" and a list of compilation errors, modify the code such that the errors are resolved.
-	The response must contain only the source code and nothing else.
+	The response must contain only the source code in a fenced code block and nothing else.
 
 	` + "```" + `{{ .Language.ID }}
 	{{ .Code }}

--- a/model/llm/llm.go
+++ b/model/llm/llm.go
@@ -77,7 +77,7 @@ type llmSourceFilePromptContext struct {
 var llmGenerateTestForFilePromptTemplate = template.Must(template.New("model-llm-generate-test-for-file-prompt").Parse(bytesutil.StringTrimIndentations(`
 	Given the following {{ .Language.Name }} code file "{{ .FilePath }}" with package "{{ .ImportPath }}", provide a test file for this code{{ with $testFramework := .Language.TestFramework }} with {{ $testFramework }} as a test framework{{ end }}.
 	The tests should produce 100 percent code coverage and must compile.
-	The response must contain only the test code and nothing else.
+	The response must contain only the test code in a fenced code block and nothing else.
 
 	` + "```" + `{{ .Language.ID }}
 	{{ .Code }}

--- a/model/llm/llm_test.go
+++ b/model/llm/llm_test.go
@@ -324,7 +324,7 @@ func TestLLMCodeRepairSourceFilePrompt(t *testing.T) {
 
 		ExpectedMessage: bytesutil.StringTrimIndentations(`
 			Given the following Go code file "/path/to/foobar.go" with package "foobar" and a list of compilation errors, modify the code such that the errors are resolved.
-			The response must contain only the source code and nothing else.
+			The response must contain only the source code in a fenced code block and nothing else.
 
 			` + "```" + `golang
 			package foobar


### PR DESCRIPTION
Part of #257 