### PR TITLE
Make the Java Knapsack inner class static, so it is easier for LLMs to solve 

### DIFF
--- a/testdata/java/light/src/main/java/com/eval/Knapsack.java
+++ b/testdata/java/light/src/main/java/com/eval/Knapsack.java
@@ -26,7 +26,7 @@ public class Knapsack {
     return knapsack[items.length][maximumWeight];
   }
 
-  class Item {
+  static class Item {
     int weight;
     int value;
   }


### PR DESCRIPTION
Part of #230 