### PR TITLE
Use Linux file paths on prompts even if the evaluation is running on a Windows machine, so the prompt is always the same

### DIFF
--- a/model/llm/llm.go
+++ b/model/llm/llm.go
@@ -68,6 +68,8 @@ var llmGenerateTestForFilePromptTemplate = template.Must(template.New("model-llm
 
 // llmGenerateTestForFilePrompt returns the prompt for generating an LLM test generation.
 func llmGenerateTestForFilePrompt(data *llmSourceFilePromptContext) (message string, err error) {
+	// Use Linux paths even when running the evaluation on Windows to ensure consistency in prompting.
+	data.FilePath = filepath.ToSlash(data.FilePath)
 	data.Code = strings.TrimSpace(data.Code)
 
 	var b strings.Builder
@@ -102,6 +104,8 @@ var llmCodeRepairSourceFilePromptTemplate = template.Must(template.New("model-ll
 
 // llmCodeRepairSourceFilePrompt returns the prompt to code repair a source file.
 func llmCodeRepairSourceFilePrompt(data *llmCodeRepairSourceFilePromptContext) (message string, err error) {
+	// Use Linux paths even when running the evaluation on Windows to ensure consistency in prompting.
+	data.FilePath = filepath.ToSlash(data.FilePath)
 	data.Code = strings.TrimSpace(data.Code)
 
 	var b strings.Builder

--- a/model/llm/llm_test.go
+++ b/model/llm/llm_test.go
@@ -307,36 +307,38 @@ func TestLLMCodeRepairSourceFilePrompt(t *testing.T) {
 				Language: &golang.Language{},
 
 				Code: bytesutil.StringTrimIndentations(`
-					package foobar
-					func foobar(i int) int
+					package increment
+
+					func increment(i int) int
 						return i + 1
 					}
 				`),
-				FilePath:   "/path/to/foobar.go",
-				ImportPath: "foobar",
+				FilePath:   "/path/to/increment.go",
+				ImportPath: "increment",
 			},
 			Mistakes: []string{
-				"/path/to/foobar.go:3:1: expected 'IDENT', found 'func'",
-				"/path/to/foobar.go: syntax error: non-declaration statement outside function body",
-				"/path/to/foobar.go: missing return",
+				"/path/to/increment.go:3:1: expected 'IDENT', found 'func'",
+				"/path/to/increment.go: syntax error: non-declaration statement outside function body",
+				"/path/to/increment.go: missing return",
 			},
 		},
 
 		ExpectedMessage: bytesutil.StringTrimIndentations(`
-			Given the following Go code file "/path/to/foobar.go" with package "foobar" and a list of compilation errors, modify the code such that the errors are resolved.
+			Given the following Go code file "/path/to/increment.go" with package "increment" and a list of compilation errors, modify the code such that the errors are resolved.
 			The response must contain only the source code in a fenced code block and nothing else.
 
 			` + "```" + `golang
-			package foobar
-			func foobar(i int) int
+			package increment
+
+			func increment(i int) int
 				return i + 1
 			}
 			` + "```" + `
 
 			The list of compilation errors is the following:
-			- /path/to/foobar.go:3:1: expected 'IDENT', found 'func'
-			- /path/to/foobar.go: syntax error: non-declaration statement outside function body
-			- /path/to/foobar.go: missing return
+			- /path/to/increment.go:3:1: expected 'IDENT', found 'func'
+			- /path/to/increment.go: syntax error: non-declaration statement outside function body
+			- /path/to/increment.go: missing return
 		`),
 	})
 }


### PR DESCRIPTION
Part of #152