### PR TITLE
Shut down the Ollama service if there are no Ollama models to evaluate, to avoid unnecessary processes being opened

### DIFF
--- a/cmd/eval-dev-quality/cmd/evaluate.go
+++ b/cmd/eval-dev-quality/cmd/evaluate.go
@@ -300,10 +300,25 @@ func (command *Evaluate) Initialize(args []string) (evaluationContext *evaluate.
 
 	// Gather models.
 	{
+		// Check which providers are needed for the evaluation.
+		providersSelected := map[string]provider.Provider{}
+		if len(command.Models) == 0 {
+			providersSelected = provider.Providers
+		} else {
+			for _, model := range command.Models {
+				p := strings.SplitN(model, provider.ProviderModelSeparator, 2)[0]
+				if provider, ok := provider.Providers[p]; !ok {
+					command.logger.Panicf("Provider %q does not exist", p)
+				} else {
+					providersSelected[provider.ID()] = provider
+				}
+			}
+		}
+
 		models := map[string]model.Model{}
 		modelsSelected := map[string]model.Model{}
 		evaluationContext.ProviderForModel = map[model.Model]provider.Provider{}
-		for _, p := range provider.Providers {
+		for _, p := range providersSelected {
 			command.logger.Printf("Checking provider %q for models", p.ID())
 
 			if t, ok := p.(provider.InjectToken); ok {

--- a/cmd/eval-dev-quality/cmd/evaluate_test.go
+++ b/cmd/eval-dev-quality/cmd/evaluate_test.go
@@ -525,6 +525,31 @@ func TestEvaluateExecute(t *testing.T) {
 						filepath.Join("result-directory", "README.md"): nil,
 						filepath.Join("result-directory", string(evaluatetask.IdentifierWriteTests), "ollama_"+log.CleanModelNameForFileSystem(providertesting.OllamaTestModel), "golang", "golang", "plain.log"): nil,
 					},
+					ExpectedOutputValidate: func(t *testing.T, output, resultPath string) {
+						assert.Contains(t, output, `Starting services for provider "ollama"`)
+					},
+				})
+			}
+			{
+				validate(t, &testCase{
+					Name: "Ollama services are not started",
+
+					Arguments: []string{
+						"--language", "golang",
+						"--model", "symflower/symbolic-execution",
+						"--repository", filepath.Join("golang", "plain"),
+					},
+
+					ExpectedResultFiles: map[string]func(t *testing.T, filePath string, data string){
+						filepath.Join("result-directory", "categories.svg"): nil,
+						filepath.Join("result-directory", "evaluation.csv"): nil,
+						filepath.Join("result-directory", "evaluation.log"): nil,
+						filepath.Join("result-directory", "README.md"):      nil,
+						filepath.Join("result-directory", string(evaluatetask.IdentifierWriteTests), "symflower_symbolic-execution", "golang", "golang", "plain.log"): nil,
+					},
+					ExpectedOutputValidate: func(t *testing.T, output, resultPath string) {
+						assert.NotContains(t, output, `Starting services for provider "ollama"`)
+					},
 				})
 			}
 		})


### PR DESCRIPTION
Part of #225