### PR TITLE
fix, Use the correct Maven snapshot format in the Java test data, to have a cleaner output without warnings

### DIFF
--- a/testdata/java/light/pom.xml
+++ b/testdata/java/light/pom.xml
@@ -9,6 +9,7 @@
 	<properties>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>
 		<plugins>

--- a/testdata/java/light/pom.xml
+++ b/testdata/java/light/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eval.dev.quality</groupId>
 	<artifactId>test-java-light</artifactId>
-	<version>SNAPSHOT</version>
+	<version>1.0-SNAPSHOT</version>
 	<properties>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>

--- a/testdata/java/mistakes/importMissing/pom.xml
+++ b/testdata/java/mistakes/importMissing/pom.xml
@@ -10,6 +10,7 @@
 	<properties>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<build>

--- a/testdata/java/mistakes/importMissing/pom.xml
+++ b/testdata/java/mistakes/importMissing/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eval.dev.quality</groupId>
 	<artifactId>import-missing</artifactId>
-	<version>SNAPSHOT</version>
+	<version>1.0-SNAPSHOT</version>
 
 	<properties>
 		<maven.compiler.source>11</maven.compiler.source>

--- a/testdata/java/mistakes/openingBracketMissing/pom.xml
+++ b/testdata/java/mistakes/openingBracketMissing/pom.xml
@@ -10,6 +10,7 @@
 	<properties>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<build>

--- a/testdata/java/mistakes/openingBracketMissing/pom.xml
+++ b/testdata/java/mistakes/openingBracketMissing/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eval.dev.quality</groupId>
 	<artifactId>opening-bracket-missing</artifactId>
-	<version>SNAPSHOT</version>
+	<version>1.0-SNAPSHOT</version>
 
 	<properties>
 		<maven.compiler.source>11</maven.compiler.source>

--- a/testdata/java/mistakes/syntaxErrorTypeMissing/pom.xml
+++ b/testdata/java/mistakes/syntaxErrorTypeMissing/pom.xml
@@ -10,6 +10,7 @@
 	<properties>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<build>

--- a/testdata/java/mistakes/syntaxErrorTypeMissing/pom.xml
+++ b/testdata/java/mistakes/syntaxErrorTypeMissing/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eval.dev.quality</groupId>
 	<artifactId>syntax-error-type-missing</artifactId>
-	<version>SNAPSHOT</version>
+	<version>1.0-SNAPSHOT</version>
 
 	<properties>
 		<maven.compiler.source>11</maven.compiler.source>

--- a/testdata/java/mistakes/typeUnknown/pom.xml
+++ b/testdata/java/mistakes/typeUnknown/pom.xml
@@ -10,6 +10,7 @@
 	<properties>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<build>

--- a/testdata/java/mistakes/typeUnknown/pom.xml
+++ b/testdata/java/mistakes/typeUnknown/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eval.dev.quality</groupId>
 	<artifactId>type-unknown</artifactId>
-	<version>SNAPSHOT</version>
+	<version>1.0-SNAPSHOT</version>
 
 	<properties>
 		<maven.compiler.source>11</maven.compiler.source>

--- a/testdata/java/mistakes/variableUnknown/pom.xml
+++ b/testdata/java/mistakes/variableUnknown/pom.xml
@@ -10,6 +10,7 @@
 	<properties>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<build>

--- a/testdata/java/mistakes/variableUnknown/pom.xml
+++ b/testdata/java/mistakes/variableUnknown/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eval.dev.quality</groupId>
 	<artifactId>variable-unknown</artifactId>
-	<version>SNAPSHOT</version>
+	<version>1.0-SNAPSHOT</version>
 
 	<properties>
 		<maven.compiler.source>11</maven.compiler.source>

--- a/testdata/java/plain/pom.xml
+++ b/testdata/java/plain/pom.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eval.dev.quality</groupId>
 	<artifactId>test-java-plain</artifactId>
-	<version>SNAPSHOT</version>
+	<version>1.0-SNAPSHOT</version>
 	<properties>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>

--- a/testdata/java/plain/pom.xml
+++ b/testdata/java/plain/pom.xml
@@ -9,6 +9,7 @@
 	<properties>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>
 		<plugins>

--- a/testdata/java/transpile/balancedBrackets/pom.xml
+++ b/testdata/java/transpile/balancedBrackets/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eval.dev.quality</groupId>
 	<artifactId>balanced-brackets</artifactId>
-	<version>SNAPSHOT</version>
+	<version>1.0-SNAPSHOT</version>
 	<properties>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>

--- a/testdata/java/transpile/balancedBrackets/pom.xml
+++ b/testdata/java/transpile/balancedBrackets/pom.xml
@@ -9,6 +9,7 @@
 	<properties>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>
 		<plugins>

--- a/testdata/java/transpile/binarySearch/pom.xml
+++ b/testdata/java/transpile/binarySearch/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eval.dev.quality</groupId>
 	<artifactId>binary-search</artifactId>
-	<version>SNAPSHOT</version>
+	<version>1.0-SNAPSHOT</version>
 	<properties>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>

--- a/testdata/java/transpile/binarySearch/pom.xml
+++ b/testdata/java/transpile/binarySearch/pom.xml
@@ -9,6 +9,7 @@
 	<properties>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>
 		<plugins>

--- a/testdata/java/transpile/cascadingIfElse/pom.xml
+++ b/testdata/java/transpile/cascadingIfElse/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eval.dev.quality</groupId>
 	<artifactId>cascading-if-else</artifactId>
-	<version>SNAPSHOT</version>
+	<version>1.0-SNAPSHOT</version>
 	<properties>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>

--- a/testdata/java/transpile/cascadingIfElse/pom.xml
+++ b/testdata/java/transpile/cascadingIfElse/pom.xml
@@ -9,6 +9,7 @@
 	<properties>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>
 		<plugins>

--- a/testdata/java/transpile/isSorted/pom.xml
+++ b/testdata/java/transpile/isSorted/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eval.dev.quality</groupId>
 	<artifactId>is-sorted</artifactId>
-	<version>SNAPSHOT</version>
+	<version>1.0-SNAPSHOT</version>
 	<properties>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>

--- a/testdata/java/transpile/isSorted/pom.xml
+++ b/testdata/java/transpile/isSorted/pom.xml
@@ -9,6 +9,7 @@
 	<properties>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>
 		<plugins>

--- a/testdata/java/transpile/pascalsTriangle/pom.xml
+++ b/testdata/java/transpile/pascalsTriangle/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eval.dev.quality</groupId>
 	<artifactId>cascading-if-else</artifactId>
-	<version>SNAPSHOT</version>
+	<version>1.0-SNAPSHOT</version>
 	<properties>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>

--- a/testdata/java/transpile/pascalsTriangle/pom.xml
+++ b/testdata/java/transpile/pascalsTriangle/pom.xml
@@ -9,6 +9,7 @@
 	<properties>
 		<maven.compiler.target>11</maven.compiler.target>
 		<maven.compiler.source>11</maven.compiler.source>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>
 		<plugins>


### PR DESCRIPTION
Part of #270 